### PR TITLE
fix: Run on Node.js@20

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -20,7 +20,7 @@ inputs:
     description: 'A JSON string mapping task types to custom label names. Example: {"feat": "feature", "fix": "fix", "docs": "documentation", "test": "test", "ci": "CI/CD", "refactor": "refactor", "perf": "performance", "chore": "chore", "revert": "revert", "wip": "WIP"}'
     required: false
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'
 branding:
   icon: "git-pull-request"


### PR DESCRIPTION
Because of this deprecation message in GitHub Actions...

Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: ytanikin/PRConventionalCommits@1.1.0. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

Tested [here](https://github.com/uktrade/copilot-tools/actions/runs/8093390633).