### PR TITLE
fix(ci/Docker): Update entrypoint to absolute path for the action entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ RUN npm ci --only=production
 COPY . .
 
 # Run the action
-ENTRYPOINT ["node", "index.js"]
+ENTRYPOINT ["node", "/index.js"]


### PR DESCRIPTION
The entrypoint needs to use an absolute path as `intex.js` is in the root of the container, while the client project is mounted in `/github/workspace`.

I made a test (this time using the reference to the action in my branch, not the local action), and apparently fine. The test here: https://github.com/gerardbosch/pr-conventional-commits/pull/3/commits/ae45dc77fe699ed136d2a53245c8ca9b03222814

Fixes #51 